### PR TITLE
MNT: update asyn for R.9-ess

### DIFF
--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -14,7 +14,7 @@
 # ==========================================================
 # Define the version strings for all needed modules
 # ==========================================================
-ASYN_MODULE_VERSION		= R4.39-1.0.2
+ASYN_MODULE_VERSION		= R4.42-1.0.0
 
 # ==========================================================
 # External Support module path definitions


### PR DESCRIPTION
This PR simply updates the asyn version of the R.9-ess branch to the same version used in our other IOCs.

This is part of a collection of PRs aimed at solving https://jira.slac.stanford.edu/browse/ECS-8732

Related PRs:

1. https://github.com/slac-epics/motor/pull/2
2. https://github.com/pcdshub/ethercatmc/pull/4
3. https://github.com/pcdshub/twincat-ads/pull/19
4. https://github.com/pcdshub/ioc-common-ads-ioc/pull/110