### PR TITLE
Fix missing SmartSetCANAddress function

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,7 @@
-R6.10.1.-2.6.0 (aberges)
+R6.10.1-2.6.1 (lorelli)
+    Fixed missing SmartSetCANAddress IOCSH function
+
+R6.10.1-2.6.0 (aberges)
     Update smarActMCS2Motor Driver to mitigate operational failures:
         - holdTime now defaults to 10 sec. Can be set with downstream common
           IOCs using streamDevice protocols

--- a/motorApp/SmartMotorAsynSrc/SmartController.cpp
+++ b/motorApp/SmartMotorAsynSrc/SmartController.cpp
@@ -438,7 +438,7 @@ static void SmartSetCANAddressCallFunc(const iocshArgBuf *args) {
 }
 static void SmartMotorAsynRegister(void) {
   iocshRegister(&SmartCreateControllerDef, SmartCreateContollerCallFunc);
-  iocshRegister(&SmartCreateControllerDef, SmartCreateContollerCallFunc);
+  iocshRegister(&SmartSetCANAddressDef, SmartSetCANAddressCallFunc);
 }
 
 extern "C" {


### PR DESCRIPTION
Typo from when someone brought over the R6.9 changes