### PR TITLE
Prevent MIP log messages from spamming in EPICS motor record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ auto_settings.sav*
 auto_positions.sav*
 .ccfxprepdir/
 *.local
+.vscode/

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,6 @@
+R6.9-ess-0.0.5  2026-08-25 Jane Liu
+	Fix ECS-3981: Prevent spammy MIP messages and log only an actual state transition.
+
 R6.9-ess-0.0.4  2025-10-10 Zachary Lentz
     Build against asyn/R4.42-1.0.0
 

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -389,8 +389,7 @@ enum moveMode{
 
 
 /******************************************************************************
- * Debug MIP and MIP changes
- * Not yet used (needs better printing)
+ * Debug formatting and logging for MIP state changes
 *******************************************************************************/
 static void mipSetBit(motorRecord *pmr, unsigned v)
 {
@@ -412,6 +411,13 @@ static void mipSetMip(motorRecord *pmr, unsigned v)
 static void dbgMipToString(unsigned v, char *buf, size_t buflen)
 {
   int len;
+
+  if (v == MIP_DONE)
+  {
+      epicsSnprintf(buf, buflen, "'DONE'");
+      return;
+  }
+
   memset(buf, 0, buflen);
   len = epicsSnprintf(buf, buflen-1,
            "'%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s'",
@@ -442,8 +448,8 @@ static void dbgMipToString(unsigned v, char *buf, size_t buflen)
   }
 }
 
-/*  abbreviated Bits: */
-/* Jf Jr J1 Hf Hr Mo Rt Lp MB St Dr Da JR Js J2 Ex */
+/* MIP_DONE is printed as DONE.  Nonzero bits are abbreviated as follows: */
+/* Jf Jr J1 Hf Hr Mo Ry Lp Mb St Dr Da jR jS J2 Ex */
 /* 16 bits * 3 + NUL + spare */
 #define MBLE 50
 
@@ -486,7 +492,7 @@ static void dbgMipToString(unsigned v, char *buf, size_t buflen)
     mipSetMip(pmr,(v));                              \
     /* Prevent spammy MIP messages and log only an   \
      * actual state transition. */                   \
-    if (old != pmr->mip) {                           \
+    if (old != MIP_DONE || pmr->mip != MIP_DONE) {  \
         char obuf[MBLE];                             \
         char nbuf[MBLE];                             \
         dbgMipToString(old, obuf, sizeof(obuf));     \

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -482,16 +482,20 @@ static void dbgMipToString(unsigned v, char *buf, size_t buflen)
 
 #define MIP_SET_VAL(v)                               \
   do {                                               \
-    char obuf[MBLE];                                 \
-    char nbuf[MBLE];                                 \
     epicsUInt16 old = pmr->mip;                      \
     mipSetMip(pmr,(v));                              \
-    dbgMipToString(old, obuf, sizeof(obuf));         \
-    dbgMipToString(pmr->mip, nbuf, sizeof(nbuf));    \
-    Debug(pmr,2, "%s:%d %s mipSetVal old=%s new=%s\n",   \
-          __FILE__, __LINE__, pmr->name,             \
-          obuf, nbuf);                               \
+    /* Prevent spammy MIP messages and log only an   \
+     * actual state transition. */                   \
+    if (old != pmr->mip) {                           \
+        char obuf[MBLE];                             \
+        char nbuf[MBLE];                             \
+        dbgMipToString(old, obuf, sizeof(obuf));     \
+        dbgMipToString(pmr->mip, nbuf, sizeof(nbuf));\
+        Debug(pmr,2, "%s:%d %s mipSetVal old=%s new=%s\n", \
+              __FILE__, __LINE__, pmr->name,         \
+              obuf, nbuf);                           \
     }                                                \
+  }                                                  \
   while(0)
 
 #else

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -412,12 +412,6 @@ static void dbgMipToString(unsigned v, char *buf, size_t buflen)
 {
   int len;
 
-  if (v == MIP_DONE)
-  {
-      epicsSnprintf(buf, buflen, "'DONE'");
-      return;
-  }
-
   memset(buf, 0, buflen);
   len = epicsSnprintf(buf, buflen-1,
            "'%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s'",
@@ -448,8 +442,8 @@ static void dbgMipToString(unsigned v, char *buf, size_t buflen)
   }
 }
 
-/* MIP_DONE is printed as DONE.  Nonzero bits are abbreviated as follows: */
-/* Jf Jr J1 Hf Hr Mo Ry Lp Mb St Dr Da jR jS J2 Ex */
+/*  abbreviated Bits: */
+/* Jf Jr J1 Hf Hr Mo Rt Lp MB St Dr Da JR Js J2 Ex */
 /* 16 bits * 3 + NUL + spare */
 #define MBLE 50
 


### PR DESCRIPTION
This PR fixes an issue where Beckhoff motor record repeatedly prints messages, like `mipSetVal old='' new=''` when no motor state change occurred. This bug is described in a Jira ticket at https://jira.slac.stanford.edu/browse/ECS-3981

**Problem Details**
The EPICS motor record tracks its current motion state using `MIP` (Motion in Progress) bitmask. The motor record prints a diagnostic message every time the `MIP_SET_VAL` macro assigns a MIP value, even when the value didn't change. When a motor is already in the completed state, repeated assignments of the MIP value ends up spamming messages like `mipSetVal old='' new=''`.

**Solution**
The fix takes the current MIP value and compares it to the previous MIP value. If the values are different, the `MIP_SET_VAL` macro will print a message. If both current and previous MIP values are `DONE` (this renders as an empty string), the message will be suppressed. `MIP_SET_VAL` will print only when there is at least one meaningful MIP value.

Currently, the `MIP_DONE` displays as an empty string. For example, if the previous state was RETRY and current state is DONE, the MIP log message displays `mipSetVal old='Ry' new=''`. This abbreviation and empty string unfortunately aren't very informative to the user. I was thinking about expanding 'Ry' to 'RETRY', but if there is any kind of external tool monitoring these MIP log messages, changing them might cause other problems. So I just hid the `mipSetVal old='' new=''` spam.

**Testing and Validation**
1. Replicated the bug using `lcls-plc-example-motion` and a test PLC in Maker Space (`PLC-TST-MKR-02`). While moving the simulated axis back and forth to its high and low limits, only one spammy `mipSetVal old='' new=''` was observed in the IOC shell each time the motor hit a limit. I was unable to get the message to spam multiple lines.

<img width="1235" height="985" alt="Screenshot 2026-08-28 173314" src="https://github.com/user-attachments/assets/7ea8e4bb-97ea-427a-9f55-3037969766a8" />

2. In `lcls-plc-example-motion/iocBoot/ioc-tc-mot-example/Makefile` updated `IOC_TOP` to point to a rebuilt version of ads-ioc with the MOTOR module pointing to the updated module in my dev workspace. 

3. Performed the same tests and observed that `mipSetVal old='' new=''` no longer appears in the IOC shell when moving the simulated axis to high and low limits.

```
(dev-pcds-6.0.1) janeliu@psbuild-rocky9-01:ioc-tc-mot-example $ ./st.cmd
#!/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/bin/rhel9-x86_64/adsIoc
################### AUTO-GENERATED DO NOT EDIT ###################
#
#         Project: lcls-plc-example-motion.tsproj
#        PLC name: tc_mot_example (tc_mot_example Instance)
# Generated using: pytmc 2.21.1.dev22+g73aae58
# Project version: d6d6390
#    Project hash: d6d6390ad9d4d2a8dfedd5b8089f1b2f21e3066d
#     PLC IP/host: 172.21.148.161 (Specified in Makefile; project has: 172.21.148.148)
#      PLC Net ID: 172.21.148.161.1.1 (Specified in Makefile; project has: 172.21.148.148.1.1)
# ** DEVELOPMENT MODE IOC **
# * Using IOC boot directory for autosave.
# * Archiver settings will not be configured.
#
# Libraries:
#
#   LCLS General: * -> 2.9.1 (SLAC)
#   lcls-twincat-common-components: * -> 3.0.1 (SLAC)
#   lcls-twincat-motion: * -> 4.0.2 (SLAC)
#   PMPS: * -> 3.0.14 (SLAC - LCLS)
#   Tc2_SerialCom: * (Beckhoff Automation GmbH)
#   Tc2_Standard: * (Beckhoff Automation GmbH)
#   Tc2_System: * (Beckhoff Automation GmbH)
#   Tc3_Module: * (Beckhoff Automation GmbH)
#
################### AUTO-GENERATED DO NOT EDIT ###################
# Run common startup commands for linux soft IOC's
< /reg/d/iocCommon/All/pre_linux.cmd
#==============================================================
#
#  Abs:  Soft IOC pre-startup initialization (Production)
#
#  Name: pre_linux.cmd
#
#  Facility: LCLS Controls
#
#  Auth: 27-Jul-2009, Bruce Hill (bhill)
#  Rev:  dd-mmm-yyyy, Reviewer's Name (USERNAME)
#                       Based on soft_pre_st.cmd from LCLS
#  Mod:
#       dd-mmm-yyyy, Firstname Lastname (USERNAME):
#         comment
#
#==============================================================
#
# Time...
epicsEnvSet("EPICS_TS_NTP_INET","psntp.slac.stanford.edu")
# iocLogClient...
epicsEnvSet("EPICS_IOC_LOG_FILE_LIMIT","1000000")
epicsEnvSet("EPICS_IOC_LOG_FILE_COMMAND","")
# iocLogClient: Send log messages to logstash:
epicsEnvSet("EPICS_IOC_LOG_INET", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_IOC_LOG_PORT", "7004")
# The following prefix is *required* for logstash to know which IOC is sending
# the message.  This *cannot* be modified without changes to the logstash
# configuration.
macLib: macro IOC is undefined (expanding string iocLogPrefix("IOC=${IOC} "))
# caPutLog: Send caPutLog messages to logstash:
epicsEnvSet("EPICS_CAPUTLOG_HOST", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_CAPUTLOG_PORT", "7011")
epicsEnvSet("EPICS_CA_PUT_LOG_ADDR", "ctl-logsrv01.pcdsn:7011")
# TODO: Need a way to conditionally set these based on the host so ioc-xcs-misc1 and others don't send CA traffic over fez
# Channel Access...
epicsEnvSet("EPICS_CA_ADDR_LIST","")
epicsEnvSet("EPICS_CA_REPEATER_PORT","5065")
epicsEnvSet("EPICS_CA_SERVER_PORT","5064")
epicsEnvSet("EPICS_CA_CONN_TMO","10.0")
epicsEnvSet("EPICS_CA_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_SEARCH_PERIOD","60.0")
epicsEnvSet("EPICS_CA_AUTO_ADDR_LIST","YES")
epicsEnvSet("EPICS_CAS_INTF_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_AUTO_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_SERVER_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", "4000000")
# Let's add this for pvaccess support.  If it's not compiled in, it can't hurt,
# and if you really want it off, you can do that in the st.cmd after including
# this.
epicsEnvSet( "EPICS_PVA_AUTO_ADDR_LIST",         "TRUE" )
epicsEnvSet( "EPICS_PVAS_AUTO_BEACON_ADDR_LIST", "TRUE" )
# Enable ioc error logging
setIocLogDisable 0
< envPaths
epicsEnvSet("IOC","ioc-tc-mot-example")
epicsEnvSet("TOP","/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc")
epicsEnvSet("EPICS_SITE_TOP","/cds/group/pcds/epics")
epicsEnvSet("EPICS_MODULES","/cds/group/pcds/epics/R7.0.3.1-2.0/modules")
epicsEnvSet("MY_MODULES","/cds/group/pcds/epics-dev/janeliu/slac-epics")
epicsEnvSet("AUTOSAVE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.0.0")
epicsEnvSet("IOCADMIN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0")
epicsEnvSet("ETHERCATMC","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/ethercatmc/R2.1.0-0.1.5")
epicsEnvSet("MOTOR","/cds/group/pcds/epics-dev/janeliu/slac-epics/motor")
epicsEnvSet("ASYN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/asyn/R4.42-1.0.0")
epicsEnvSet("ADS","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/twincat-ads/R2.0.0-1.1.1")
epicsEnvSet("CAPUTLOG","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/caPutLog/R4.0-1.0.0")
epicsEnvSet("STREAMDEVICE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/streamdevice/R2.8.9-1.3.2")
epicsEnvSet("EPICS_BASE","/cds/group/pcds/epics/base/R7.0.3.1-2.0")
epicsEnvSet("IOC_TOP", "/cds/group/pcds/epics-dev/janeliu/iocs/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example")
epicsEnvSet("IOC_DATA", "/cds/data/iocData")
epicsEnvSet("ADS_IOC_TOP", "/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc" )
epicsEnvSet("ENGINEER", "janeliu" )
epicsEnvSet("LOCATION", "PLC:TST:MOT" )
epicsEnvSet("IOCSH_PS1", "ioc-tc-mot-example> " )
epicsEnvSet("ACF_FILE", "/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/iocBoot/templates/unrestricted.acf")
# Register all support components
dbLoadDatabase("/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/dbd/adsIoc.dbd")
adsIoc_registerRecordDeviceDriver(pdbbase)
epicsEnvSet("ASYN_PORT",        "ASYN_PLC")
epicsEnvSet("IPADDR",           "172.21.148.161")
epicsEnvSet("AMSID",            "172.21.148.161.1.1")
epicsEnvSet("AMS_PORT",         "851")
epicsEnvSet("ADS_MAX_PARAMS",   "3270")
epicsEnvSet("ADS_SAMPLE_MS",    "50")
epicsEnvSet("ADS_MAX_DELAY_MS", "100")
epicsEnvSet("ADS_TIMEOUT_MS",   "1000")
epicsEnvSet("ADS_TIME_SOURCE",  "0")
# Add a route to the PLC automatically:
system("/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/scripts/add_route.sh 172.21.148.161 ^172.*$")
Host likely has a real admin password, skipping add route to save time.
# adsAsynPortDriverConfigure(portName, ipaddr, amsaddr, amsport,
#    asynParamTableSize, priority, noAutoConnect, defaultSampleTimeMS,
#    maxDelayTimeMS, adsTimeoutMS, defaultTimeSource)
# portName            Asyn port name
# ipAddr              IP address of PLC
# amsaddr             AMS Address of PLC
# amsport             Default AMS port in PLC (851 for first PLC)
# paramTableSize      Maximum parameter/variable count. (1000)
# priority            Asyn priority (0)
# noAutoConnect       Enable auto connect (0=enabled)
# defaultSampleTimeMS Default sample of variable (PLC ams router
#                     checks if variable changed, if changed then add to send buffer) (50ms)
# maxDelayTimeMS      Maximum delay before variable that has changed is sent to client
#                     (Linux). The variable can also be sent sooner if the ams router
#                     send buffer is filled (100ms)
# adsTimeoutMS        Timeout for adslib commands (1000ms)
# defaultTimeSource   Default time stamp source of changed variable (PLC=0):
#                     PLC=0: The PLC time stamp from when the value was
#                         changed is used and set as timestamp in the EPICS record
#                         (if record TSE field is set to -2=enable asyn timestamp).
#                         This is the preferred setting.
#                     EPICS=1: The time stamp will be made when the updated data
#                         arrives in the EPICS client.
adsAsynPortDriverConfigure("ASYN_PLC", "172.21.148.161", "172.21.148.161.1.1", "851", "3270", 0, 0, "50", "100", "1000", "0")
Default Sample Time of 50 ms is too small, defaulting to 1Hz.
2026/08/28 17:13:59.949 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026/08/28 17:14:00.950 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026/08/28 17:14:01.950 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026/08/28 17:14:02.950 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026/08/28 17:14:03.950 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026/08/28 17:14:04.950 adsAsynPortDriver:adsAsynPortDriver: adsReadStateLock failed for port ASYN_PLC.
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x1
2026-08-28T17:14:04-0700 Warning: No response pending
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x2
2026-08-28T17:14:04-0700 Warning: No response pending
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x3
2026-08-28T17:14:04-0700 Warning: No response pending
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x4
2026-08-28T17:14:04-0700 Warning: No response pending
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x5
2026-08-28T17:14:04-0700 Warning: No response pending
2026-08-28T17:14:04-0700 Warning: InvokeId mismatch: waiting for 0x7 received 0x6
2026-08-28T17:14:04-0700 Warning: No response pending
2026/08/28 17:14:04.958 adsAsynPortDriver:adsAsynPortDriver: connection established for port ASYN_PLC.
## Asyn/ADS diagnostics configuration (always loaded)
#define ASYN_TRACE_ERROR     0x0001
#define ASYN_TRACEIO_DEVICE  0x0002
#define ASYN_TRACEIO_FILTER  0x0004
#define ASYN_TRACEIO_DRIVER  0x0008
#define ASYN_TRACE_FLOW      0x0010
#define ASYN_TRACE_WARNING   0x0020
#define ASYN_TRACE_INFO      0x0040
asynSetTraceMask("ASYN_PLC", -1, 0x41)
#define ASYN_TRACEIO_NODATA 0x0000
#define ASYN_TRACEIO_ASCII  0x0001
#define ASYN_TRACEIO_ESCAPE 0x0002
#define ASYN_TRACEIO_HEX    0x0004
asynSetTraceIOMask("ASYN_PLC", -1, 2)
#define ASYN_TRACEINFO_TIME 0x0001
#define ASYN_TRACEINFO_PORT 0x0002
#define ASYN_TRACEINFO_SOURCE 0x0004
#define ASYN_TRACEINFO_THREAD 0x0008
asynSetTraceInfoMask("ASYN_PLC", -1, 5)
#define AMPLIFIER_ON_FLAG_CREATE_AXIS  1
#define AMPLIFIER_ON_FLAG_WHEN_HOMING  2
#define AMPLIFIER_ON_FLAG_USING_CNEN   4
cd "/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/db"
########## Motor Configuration Block ##########
epicsEnvSet("MOTOR_PORT",     "PLC_ADS")
epicsEnvSet("PREFIX",         "PLC:TST:MOT:")
epicsEnvSet("NUMAXES",        "10")
epicsEnvSet("MOVE_POLL_RATE", "200")
epicsEnvSet("IDLE_POLL_RATE", "1000")
# Create the EthercatMC controller for the legacy (ST_MotionStage) motors.
EthercatMCCreateController("PLC_ADS", "ASYN_PLC", "10", "200", "1000")
epicsEnvSet("AXIS_NO",         "1")
epicsEnvSet("MOTOR_PREFIX",    "")
epicsEnvSet("MOTOR_NAME",      "PLC:TST:MOT:01")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M1")
epicsEnvSet("DESC",            "Main.M1 / Example 1 Simulated Working")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "1", "", "")
2026/08/28 17:14:04.964 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:04.966 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M1_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:04.966 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M1_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:04.968 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M1_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:04.968 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M1_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:04.971 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5001,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:04.971 [EthercatMCAxis.cpp:1600] setDoubleParam(1 HomPos_)=0.000000
2026/08/28 17:14:04.975 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:04.987 [EthercatMCAxis.cpp:352]  (1) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.003 [EthercatMCAxis.cpp:504] connected(1)
2026/08/28 17:14:05.003 [EthercatMCAxis.cpp:428] initialPoll(1) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:01, R=PLC:TST:MOT:01-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=1, DESC=Main.M1 / Example 1 Simulated Working, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:01, R=PLC:TST:MOT:01-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=1, DESC=Main.M1 / Example 1 Simulated Working, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:01, MOTOR_PORT=PLC_ADS, AXIS_NO=1, PREC=3")
epicsEnvSet("AXIS_NO",         "2")
epicsEnvSet("MOTOR_PREFIX",    "")
epicsEnvSet("MOTOR_NAME",      "PLC:TST:MOT:02")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M2")
epicsEnvSet("DESC",            "Main.M2 / Example 2 Simulated Broken")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "2", "", "")
2026/08/28 17:14:05.009 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.011 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M2_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.011 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M2_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.013 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M2_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.013 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M2_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.015 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5002,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.015 [EthercatMCAxis.cpp:1600] setDoubleParam(2 HomPos_)=0.000000
2026/08/28 17:14:05.019 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.031 [EthercatMCAxis.cpp:352]  (2) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.047 [EthercatMCAxis.cpp:504] connected(2)
2026/08/28 17:14:05.047 [EthercatMCAxis.cpp:428] initialPoll(2) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:02, R=PLC:TST:MOT:02-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=2, DESC=Main.M2 / Example 2 Simulated Broken, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:02, R=PLC:TST:MOT:02-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=2, DESC=Main.M2 / Example 2 Simulated Broken, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:02, MOTOR_PORT=PLC_ADS, AXIS_NO=2, PREC=3")
epicsEnvSet("AXIS_NO",         "3")
epicsEnvSet("MOTOR_PREFIX",    "")
epicsEnvSet("MOTOR_NAME",      "PLC:TST:MOT:03")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M3")
epicsEnvSet("DESC",            "Main.M3 / Example 3 Simulated Limits")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "3", "", "")
2026/08/28 17:14:05.053 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.055 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M3_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.055 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M3_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.057 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M3_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.057 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M3_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.059 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5003,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.059 [EthercatMCAxis.cpp:1600] setDoubleParam(3 HomPos_)=0.000000
2026/08/28 17:14:05.063 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.075 [EthercatMCAxis.cpp:352]  (3) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.091 [EthercatMCAxis.cpp:504] connected(3)
2026/08/28 17:14:05.091 [EthercatMCAxis.cpp:428] initialPoll(3) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:03, R=PLC:TST:MOT:03-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=3, DESC=Main.M3 / Example 3 Simulated Limits, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:03, R=PLC:TST:MOT:03-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=3, DESC=Main.M3 / Example 3 Simulated Limits, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=, MOTOR_NAME=PLC:TST:MOT:03, MOTOR_PORT=PLC_ADS, AXIS_NO=3, PREC=3")
epicsEnvSet("AXIS_NO",         "4")
epicsEnvSet("MOTOR_PREFIX",    "IMTST:XTES:")
epicsEnvSet("MOTOR_NAME",      "MMS")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M4")
epicsEnvSet("DESC",            "Main.M4 / Example 4 XPIM Y")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "4", "", "")
2026/08/28 17:14:05.097 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.099 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M4_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.099 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M4_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.101 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M4_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.101 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M4_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.103 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5004,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.103 [EthercatMCAxis.cpp:1600] setDoubleParam(4 HomPos_)=0.000000
2026/08/28 17:14:05.107 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.119 [EthercatMCAxis.cpp:352]  (4) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.136 [EthercatMCAxis.cpp:504] connected(4)
2026/08/28 17:14:05.136 [EthercatMCAxis.cpp:428] initialPoll(4) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=MMS, R=MMS-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=4, DESC=Main.M4 / Example 4 XPIM Y, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=MMS, R=MMS-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=4, DESC=Main.M4 / Example 4 XPIM Y, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=MMS, MOTOR_PORT=PLC_ADS, AXIS_NO=4, PREC=3")
epicsEnvSet("AXIS_NO",         "5")
epicsEnvSet("MOTOR_PREFIX",    "IMTST:XTES:")
epicsEnvSet("MOTOR_NAME",      "CLZ")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M5")
epicsEnvSet("DESC",            "Main.M5 / Example 5 XPIM Zoom")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "5", "", "")
2026/08/28 17:14:05.140 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.142 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M5_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.142 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M5_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.144 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M5_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.144 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M5_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.147 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5005,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.147 [EthercatMCAxis.cpp:1600] setDoubleParam(5 HomPos_)=0.000000
2026/08/28 17:14:05.151 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.163 [EthercatMCAxis.cpp:352]  (5) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.179 [EthercatMCAxis.cpp:504] connected(5)
2026/08/28 17:14:05.179 [EthercatMCAxis.cpp:428] initialPoll(5) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLZ, R=CLZ-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=5, DESC=Main.M5 / Example 5 XPIM Zoom, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLZ, R=CLZ-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=5, DESC=Main.M5 / Example 5 XPIM Zoom, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLZ, MOTOR_PORT=PLC_ADS, AXIS_NO=5, PREC=3")
epicsEnvSet("AXIS_NO",         "6")
epicsEnvSet("MOTOR_PREFIX",    "IMTST:XTES:")
epicsEnvSet("MOTOR_NAME",      "CLF")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M6")
epicsEnvSet("DESC",            "Main.M6 / Example 6 XPIM Focus")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "6", "", "")
2026/08/28 17:14:05.183 [EthercatMCAxis.cpp:1190] pollAll(1) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1352] poll(1) homed=1
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1358] poll(1) LLS=0
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1364] poll(1) HLS=0
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1392] poll(1) mvnNRdy=0 Ver=0 bBusy=0 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=0 time=0.007670
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1420] poll(1) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.187 [EthercatMCAxis.cpp:1035] poll(1) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.191 [EthercatMCAxis.cpp:1190] pollAll(2) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.195 [EthercatMCAxis.cpp:1352] poll(2) homed=1
2026/08/28 17:14:05.195 [EthercatMCAxis.cpp:1358] poll(2) LLS=1
2026/08/28 17:14:05.195 [EthercatMCAxis.cpp:1364] poll(2) HLS=1
2026/08/28 17:14:05.195 [EthercatMCAxis.cpp:1420] poll(2) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.195 [EthercatMCAxis.cpp:1035] poll(2) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.199 [EthercatMCAxis.cpp:1190] pollAll(3) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.160000
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1352] poll(3) homed=1
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1358] poll(3) LLS=1
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1364] poll(3) HLS=0
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=0 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=0.16 time=0.007976
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1420] poll(3) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.203 [EthercatMCAxis.cpp:1035] poll(3) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.207 [EthercatMCAxis.cpp:1190] pollAll(4) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.211 [EthercatMCAxis.cpp:1352] poll(4) homed=1
2026/08/28 17:14:05.211 [EthercatMCAxis.cpp:1358] poll(4) LLS=0
2026/08/28 17:14:05.211 [EthercatMCAxis.cpp:1364] poll(4) HLS=0
2026/08/28 17:14:05.211 [EthercatMCAxis.cpp:1420] poll(4) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.211 [EthercatMCAxis.cpp:1035] poll(4) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.215 [EthercatMCAxis.cpp:1190] pollAll(5) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.219 [EthercatMCAxis.cpp:1352] poll(5) homed=0
2026/08/28 17:14:05.219 [EthercatMCAxis.cpp:1358] poll(5) LLS=0
2026/08/28 17:14:05.219 [EthercatMCAxis.cpp:1364] poll(5) HLS=0
2026/08/28 17:14:05.219 [EthercatMCAxis.cpp:1420] poll(5) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.219 [EthercatMCAxis.cpp:1035] poll(5) callParamCallbacksUpdateError Error=4 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.223 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.225 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M6_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.225 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M6_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.227 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M6_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.227 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M6_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.229 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5006,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.229 [EthercatMCAxis.cpp:1600] setDoubleParam(6 HomPos_)=0.000000
2026/08/28 17:14:05.233 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.245 [EthercatMCAxis.cpp:352]  (6) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.261 [EthercatMCAxis.cpp:504] connected(6)
2026/08/28 17:14:05.261 [EthercatMCAxis.cpp:428] initialPoll(6) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLF, R=CLF-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=6, DESC=Main.M6 / Example 6 XPIM Focus, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLF, R=CLF-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=6, DESC=Main.M6 / Example 6 XPIM Focus, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=IMTST:XTES:, MOTOR_NAME=CLF, MOTOR_PORT=PLC_ADS, AXIS_NO=6, PREC=3")
epicsEnvSet("AXIS_NO",         "7")
epicsEnvSet("MOTOR_PREFIX",    "PLC:TST:MOT:3D:")
epicsEnvSet("MOTOR_NAME",      "X")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M7")
epicsEnvSet("DESC",            "Main.M7 / Example 7 3D X")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "7", "", "")
2026/08/28 17:14:05.267 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.269 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M7_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.269 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M7_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.271 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M7_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.271 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M7_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.273 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5007,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.273 [EthercatMCAxis.cpp:1600] setDoubleParam(7 HomPos_)=0.000000
2026/08/28 17:14:05.277 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.289 [EthercatMCAxis.cpp:352]  (7) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.305 [EthercatMCAxis.cpp:504] connected(7)
2026/08/28 17:14:05.305 [EthercatMCAxis.cpp:428] initialPoll(7) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=X, R=X-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=7, DESC=Main.M7 / Example 7 3D X, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=X, R=X-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=7, DESC=Main.M7 / Example 7 3D X, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=X, MOTOR_PORT=PLC_ADS, AXIS_NO=7, PREC=3")
epicsEnvSet("AXIS_NO",         "8")
epicsEnvSet("MOTOR_PREFIX",    "PLC:TST:MOT:3D:")
epicsEnvSet("MOTOR_NAME",      "Y")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M8")
epicsEnvSet("DESC",            "Main.M8 / Example 8 3D Y")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "8", "", "")
2026/08/28 17:14:05.311 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.313 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M8_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.313 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M8_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.315 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M8_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.315 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M8_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.317 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5008,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.317 [EthercatMCAxis.cpp:1600] setDoubleParam(8 HomPos_)=0.000000
2026/08/28 17:14:05.321 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.333 [EthercatMCAxis.cpp:352]  (8) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.349 [EthercatMCAxis.cpp:504] connected(8)
2026/08/28 17:14:05.349 [EthercatMCAxis.cpp:428] initialPoll(8) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Y, R=Y-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=8, DESC=Main.M8 / Example 8 3D Y, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Y, R=Y-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=8, DESC=Main.M8 / Example 8 3D Y, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Y, MOTOR_PORT=PLC_ADS, AXIS_NO=8, PREC=3")
epicsEnvSet("AXIS_NO",         "9")
epicsEnvSet("MOTOR_PREFIX",    "PLC:TST:MOT:3D:")
epicsEnvSet("MOTOR_NAME",      "Z")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M9")
epicsEnvSet("DESC",            "Main.M9 / Example 9 3D Z")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "9", "", "")
2026/08/28 17:14:05.355 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.357 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M9_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.357 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M9_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.359 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M9_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.359 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M9_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.361 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#5009,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.361 [EthercatMCAxis.cpp:1600] setDoubleParam(9 HomPos_)=0.000000
2026/08/28 17:14:05.365 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.377 [EthercatMCAxis.cpp:352]  (9) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.393 [EthercatMCAxis.cpp:504] connected(9)
2026/08/28 17:14:05.393 [EthercatMCAxis.cpp:428] initialPoll(9) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Z, R=Z-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=9, DESC=Main.M9 / Example 9 3D Z, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Z, R=Z-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=9, DESC=Main.M9 / Example 9 3D Z, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=PLC:TST:MOT:3D:, MOTOR_NAME=Z, MOTOR_PORT=PLC_ADS, AXIS_NO=9, PREC=3")
epicsEnvSet("AXIS_NO",         "10")
epicsEnvSet("MOTOR_PREFIX",    "PLC:TST:MOT:L2L:")
epicsEnvSet("MOTOR_NAME",      "MOT")
epicsEnvSet("MOTOR_ADS_PATH",  "Main.M10")
epicsEnvSet("DESC",            "Main.M10 / Example 10 Limit to Limit")
epicsEnvSet("EGU",             "mm")
epicsEnvSet("PREC",            "3")
epicsEnvSet("AXISCONFIG",      "")
epicsEnvSet("ECAXISFIELDINIT", "")
epicsEnvSet("AMPLIFIER_FLAGS", "")
# Create an EthercatMC axis instance for each legacy (ST_MotionStage) motor.
EthercatMCCreateAxis("PLC_ADS", "10", "", "")
2026/08/28 17:14:05.398 [EthercatMCHelper.cpp:247] out=ADSPORT=851/.THIS.sFeatures? in=ads;stv1 status=asynSuccess (0)
2026/08/28 17:14:05.400 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M10_EPICS_HOMPROC with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.400 [EthercatMCHelper.cpp:440] nvals=0 command="Main.M10_EPICS_HOMPROC?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.402 [adsAsynPortDriver.cpp:5485] adsAsynPortDriver:adsGetSymInfoByName: Get symbolic information failed for Main.M10_EPICS_HOMPOS with: ADSERR_DEVICE_SYMBOLNOTFOUND (0x710)
2026/08/28 17:14:05.402 [EthercatMCHelper.cpp:516] nvals=0 command="Main.M10_EPICS_HOMPOS?" response="Error: ADSERR_DEVICE_SYMBOLNOTFOUND"
2026/08/28 17:14:05.405 [EthercatMCHelper.cpp:404] out=ADSPORT=501/.ADR.16#500A,16#103,8,5? in=0.000000 homPos=0
2026/08/28 17:14:05.405 [EthercatMCAxis.cpp:1600] setDoubleParam(10 HomPos_)=0.000000
2026/08/28 17:14:05.409 [EthercatMCAxis.cpp:307] srev=1.000000 urev=0.000100
2026/08/28 17:14:05.421 [EthercatMCAxis.cpp:352]  (10) rdbd=2.000000, rdbd_tim=0.020000 rdbd_en=1
2026/08/28 17:14:05.437 [EthercatMCAxis.cpp:504] connected(10)
2026/08/28 17:14:05.437 [EthercatMCAxis.cpp:428] initialPoll(10) status=0
dbLoadRecords("EthercatMC.template", "PREFIX=PLC:TST:MOT:L2L:, MOTOR_NAME=MOT, R=MOT-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=10, DESC=Main.M10 / Example 10 Limit to Limit, PREC=3, EGU=mm ")
dbLoadRecords("EthercatMCreadback.template", "PREFIX=PLC:TST:MOT:L2L:, MOTOR_NAME=MOT, R=MOT-, MOTOR_PORT=PLC_ADS, ASYN_PORT=ASYN_PLC, AXIS_NO=10, DESC=Main.M10 / Example 10 Limit to Limit, PREC=3 ")
dbLoadRecords("EthercatMCdebug.template", "PREFIX=PLC:TST:MOT:L2L:, MOTOR_NAME=MOT, MOTOR_PORT=PLC_ADS, AXIS_NO=10, PREC=3")
dbLoadRecords("iocSoft.db", "IOC=PLC:TST:MOT")
dbLoadRecords("save_restoreStatus.db", "P=PLC:TST:MOT:")
dbLoadRecords("caPutLog.db", "IOC=ioc-tc-mot-example")
## TwinCAT task, application, and project information databases ##
dbLoadRecords("TwinCAT_TaskInfo.db", "PORT=ASYN_PLC,PREFIX=PLC:TST:MOT,IDX=1,TASK_PORT=350")
dbLoadRecords("TwinCAT_AppInfo.db", "PORT=ASYN_PLC, PREFIX=PLC:TST:MOT")
dbLoadRecords("TwinCAT_Project.db", "PREFIX=PLC:TST:MOT,PROJECT=lcls-plc-example-motion.tsproj,HASH=d6d6390,VERSION=d6d6390,PYTMC=2.21.1.dev22+g73aae58,PLC_HOST=172.21.148.161")
#   LCLS General: * -> 2.9.1 (SLAC)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=LCLS_General,VERSION=2.9.1,VENDOR=SLAC")
#   lcls-twincat-common-components: * -> 3.0.1 (SLAC)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=lcls-twincat-common-components,VERSION=3.0.1,VENDOR=SLAC")
Can't create record "PLC:TST:MOT:ProjectInfo:lcls-twincat-common-components:Vendor" of type "lsi"
Error at or before ")" in path "."  file "TwinCAT_Dependency.db" line 10
Error: syntax error
#   lcls-twincat-motion: * -> 4.0.2 (SLAC)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=lcls-twincat-motion,VERSION=4.0.2,VENDOR=SLAC")
#   PMPS: * -> 3.0.14 (SLAC - LCLS)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=PMPS,VERSION=3.0.14,VENDOR=SLAC - LCLS")
#   Tc2_SerialCom: * (Beckhoff Automation GmbH)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=Tc2_SerialCom,VERSION=*,VENDOR=Beckhoff Automation GmbH")
#   Tc2_Standard: * (Beckhoff Automation GmbH)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=Tc2_Standard,VERSION=*,VENDOR=Beckhoff Automation GmbH")
#   Tc2_System: * (Beckhoff Automation GmbH)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=Tc2_System,VERSION=*,VENDOR=Beckhoff Automation GmbH")
#   Tc3_Module: * (Beckhoff Automation GmbH)
dbLoadRecords("TwinCAT_Dependency.db", "PREFIX=PLC:TST:MOT,DEPENDENCY=Tc3_Module,VERSION=*,VENDOR=Beckhoff Automation GmbH")
cd "/cds/group/pcds/epics-dev/janeliu/iocs/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example"
## PLC Project Database files ##
dbLoadRecords("tc_mot_example.db", "PORT=ASYN_PLC,PREFIX=PLC:TST:MOT:,IOCNAME=ioc-tc-mot-example,IOC=ioc-tc-mot-example")
Can't set "IMTST:XTES:MFW:RAW:ERR:RECV_RBV.NIST" to "COMERROR_INVALIDPROCESSDATASIZE" Error (512,512)
Error at or before ")" in path "."  file "tc_mot_example.db" line 26615
Can't set "IMTST:XTES:MFW:RAW:ERR:RECV_RBV.ELST" to "COMERROR_INVALIDCHANNELNUMBER" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:RECV_RBV.TTST" to "COMERROR_INVALIDNUMDATABITS" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:RECV_RBV.FTST" to "COMERROR_INVALIDNUMSTOPBITS" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SEND_RBV.NIST" to "COMERROR_INVALIDPROCESSDATASIZE" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SEND_RBV.ELST" to "COMERROR_INVALIDCHANNELNUMBER" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SEND_RBV.TTST" to "COMERROR_INVALIDNUMDATABITS" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SEND_RBV.FTST" to "COMERROR_INVALIDNUMSTOPBITS" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SER_RBV.NIST" to "COMERROR_INVALIDPROCESSDATASIZE" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SER_RBV.ELST" to "COMERROR_INVALIDCHANNELNUMBER" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SER_RBV.TTST" to "COMERROR_INVALIDNUMDATABITS" Error (512,512)
ErrorCan't set "IMTST:XTES:MFW:RAW:ERR:SER_RBV.FTST" to "COMERROR_INVALIDNUMSTOPBITS" Error (512,512)
Error# Total records: 2270
callbackSetQueueSize(6540)
# Autosave and archive settings:
save_restoreSet_status_prefix("PLC:TST:MOT:")
save_restoreSet_IncompleteSetsOk(1)
save_restoreSet_DatedBackupFiles(1)
set_pass0_restoreFile("info_positions.sav")
set_pass1_restoreFile("info_settings.sav")
# ** Development IOC Settings **
# Development IOC autosave and archive files go in the IOC top directory:
cd "/cds/group/pcds/epics-dev/janeliu/iocs/lcls-plc-example-motion/iocBoot/ioc-tc-mot-example"
# (Development mode) Create info_positions.req and info_settings.req
makeAutosaveFiles()
# (Development mode) Create the archiver file
makeArchiveFromDbInfo("ioc-tc-mot-example.archive", "archive")
makeArchiveFromDbInfo: Wrote archive settings file containing 2584 records
# Configure access security: this is required for caPutLog.
asSetFilename("/cds/group/pcds/epics-dev/janeliu/iocs/ioc-common-ads-ioc/iocBoot/templates/unrestricted.acf")
# Initialize the IOC and start processing records
iocInit()
Starting iocInit
############################################################################
## EPICS R7.0.3.1-2.0.1
## EPICS Base built Oct 17 2024
############################################################################
drvStreamInit: Warning! STREAM_PROTOCOL_PATH not set. Defaults to "."
2026/08/28 17:14:05.521 [EthercatMCAxis.cpp:1190] pollAll(6) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.525 [EthercatMCAxis.cpp:1352] poll(6) homed=0
2026/08/28 17:14:05.525 [EthercatMCAxis.cpp:1358] poll(6) LLS=0
2026/08/28 17:14:05.525 [EthercatMCAxis.cpp:1364] poll(6) HLS=0
2026/08/28 17:14:05.525 [EthercatMCAxis.cpp:1420] poll(6) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.525 [EthercatMCAxis.cpp:1035] poll(6) callParamCallbacksUpdateError Error=4 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.529 [EthercatMCAxis.cpp:1190] pollAll(7) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.533 [EthercatMCAxis.cpp:1352] poll(7) homed=1
2026/08/28 17:14:05.533 [EthercatMCAxis.cpp:1358] poll(7) LLS=0
2026/08/28 17:14:05.533 [EthercatMCAxis.cpp:1364] poll(7) HLS=0
2026/08/28 17:14:05.533 [EthercatMCAxis.cpp:1420] poll(7) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.533 [EthercatMCAxis.cpp:1035] poll(7) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.537 [EthercatMCAxis.cpp:1190] pollAll(8) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.541 [EthercatMCAxis.cpp:1352] poll(8) homed=1
2026/08/28 17:14:05.541 [EthercatMCAxis.cpp:1358] poll(8) LLS=0
2026/08/28 17:14:05.541 [EthercatMCAxis.cpp:1364] poll(8) HLS=0
2026/08/28 17:14:05.541 [EthercatMCAxis.cpp:1420] poll(8) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.541 [EthercatMCAxis.cpp:1035] poll(8) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.545 [EthercatMCAxis.cpp:1190] pollAll(9) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.549 [EthercatMCAxis.cpp:1352] poll(9) homed=1
2026/08/28 17:14:05.549 [EthercatMCAxis.cpp:1358] poll(9) LLS=0
2026/08/28 17:14:05.549 [EthercatMCAxis.cpp:1364] poll(9) HLS=0
2026/08/28 17:14:05.549 [EthercatMCAxis.cpp:1420] poll(9) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.549 [EthercatMCAxis.cpp:1035] poll(9) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.553 [EthercatMCAxis.cpp:1190] pollAll(10) nvals=24 V1=1 V2=0 sim=0 ecmc=0 bV1BusyNew=0 Ver=0 cmd/data=3/0 fPos=0.000000 fActPos=0.000000
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1352] poll(10) homed=1
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1358] poll(10) LLS=1
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1364] poll(10) HLS=0
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1420] poll(10) bError=0 st_axis_status.nErrorId=0x0
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1035] poll(10) callParamCallbacksUpdateError Error=0 old=-1 ErrID=0x0 old=0x0 Warn=0 nCmd=0 old=0 txt=NULL
2026/08/28 17:14:05.557 [EthercatMCAxis.cpp:1478] setIntegerParam(1 motorUpdateStatus_)=1
2026/08/28 17:14:05.569 devMotorAsyn::update_soft_limits PLC:TST:MOT:01 RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:01 init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:01 init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:01 init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x4122
2026/08/28 17:14:05.569 [EthercatMCAxis.cpp:1478] setIntegerParam(2 motorUpdateStatus_)=1
2026/08/28 17:14:05.583 devMotorAsyn::update_soft_limits PLC:TST:MOT:02 RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:02 init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:02 init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:02 init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x6106
2026/08/28 17:14:05.583 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=1
2026/08/28 17:14:05.595 devMotorAsyn::update_soft_limits PLC:TST:MOT:03 RawHLM_RO=100.000000 RawLLM_RO=0.000000 valid=1 DHLM_RO=100.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:03 init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:03 init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:4100 PLC:TST:MOT:03 pmr->dhlm=100 maxValue=100
../motorRecord.cc:4163 PLC:TST:MOT:03 pmr->dllm=0 minValue=0
../motorRecord.cc:936 PLC:TST:MOT:03 init_record process_reason=2 dval=0.160000 drbv=0.160000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x6122
2026/08/28 17:14:05.595 [EthercatMCAxis.cpp:1478] setIntegerParam(4 motorUpdateStatus_)=1
2026/08/28 17:14:05.607 devMotorAsyn::update_soft_limits IMTST:XTES:MMS RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 IMTST:XTES:MMS init_record set UDF=FALSE
../motorRecord.cc:762 IMTST:XTES:MMS init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 IMTST:XTES:MMS init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x4102
2026/08/28 17:14:05.607 [EthercatMCAxis.cpp:1478] setIntegerParam(5 motorUpdateStatus_)=1
2026/08/28 17:14:05.620 devMotorAsyn::update_soft_limits IMTST:XTES:CLZ RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 IMTST:XTES:CLZ init_record set UDF=FALSE
../motorRecord.cc:762 IMTST:XTES:CLZ init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 IMTST:XTES:CLZ init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x302
2026/08/28 17:14:05.620 [EthercatMCAxis.cpp:1478] setIntegerParam(6 motorUpdateStatus_)=1
2026/08/28 17:14:05.635 devMotorAsyn::update_soft_limits IMTST:XTES:CLF RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 IMTST:XTES:CLF init_record set UDF=FALSE
../motorRecord.cc:762 IMTST:XTES:CLF init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 IMTST:XTES:CLF init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x302
2026/08/28 17:14:05.635 [EthercatMCAxis.cpp:1478] setIntegerParam(1 motorUpdateStatus_)=0
2026/08/28 17:14:05.647 [EthercatMCAxis.cpp:1478] setIntegerParam(2 motorUpdateStatus_)=0
2026/08/28 17:14:05.659 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:14:05.671 [EthercatMCAxis.cpp:1478] setIntegerParam(4 motorUpdateStatus_)=0
2026/08/28 17:14:05.683 [EthercatMCAxis.cpp:1478] setIntegerParam(5 motorUpdateStatus_)=0
2026/08/28 17:14:05.695 [EthercatMCAxis.cpp:1478] setIntegerParam(6 motorUpdateStatus_)=0
2026/08/28 17:14:05.707 [EthercatMCAxis.cpp:1478] setIntegerParam(7 motorUpdateStatus_)=1
2026/08/28 17:14:05.723 devMotorAsyn::update_soft_limits PLC:TST:MOT:3D:X RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:3D:X init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:3D:X init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:3D:X init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x4102
2026/08/28 17:14:05.723 [EthercatMCAxis.cpp:1478] setIntegerParam(8 motorUpdateStatus_)=1
2026/08/28 17:14:05.739 devMotorAsyn::update_soft_limits PLC:TST:MOT:3D:Y RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:3D:Y init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:3D:Y init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:3D:Y init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x4102
2026/08/28 17:14:05.739 [EthercatMCAxis.cpp:1478] setIntegerParam(7 motorUpdateStatus_)=0
2026/08/28 17:14:05.751 [EthercatMCAxis.cpp:1478] setIntegerParam(8 motorUpdateStatus_)=0
2026/08/28 17:14:05.763 [EthercatMCAxis.cpp:1478] setIntegerParam(9 motorUpdateStatus_)=1
2026/08/28 17:14:05.779 devMotorAsyn::update_soft_limits PLC:TST:MOT:3D:Z RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:3D:Z init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:3D:Z init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:3D:Z init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x4102
2026/08/28 17:14:05.779 [EthercatMCAxis.cpp:1478] setIntegerParam(10 motorUpdateStatus_)=1
2026/08/28 17:14:05.795 devMotorAsyn::update_soft_limits PLC:TST:MOT:L2L:MOT RawHLM_RO=0.000000 RawLLM_RO=0.000000 valid=0 DHLM_RO=0.000000 DLLM_RO=0.000000
../motorRecord.cc:906 PLC:TST:MOT:L2L:MOT init_record set UDF=FALSE
../motorRecord.cc:762 PLC:TST:MOT:L2L:MOT init_re_init udf=0 stat=17 nsta=0
../motorRecord.cc:936 PLC:TST:MOT:L2L:MOT init_record process_reason=2 dval=0.000000 drbv=0.000000 rdbd=0.000000 spdb=0.000100 udf=0 stat=0 msta=0x6102
2026/08/28 17:14:05.796 [EthercatMCAxis.cpp:1478] setIntegerParam(9 motorUpdateStatus_)=0
2026/08/28 17:14:05.808 [EthercatMCAxis.cpp:1478] setIntegerParam(10 motorUpdateStatus_)=0
2026/08/28 17:14:05.829 [adsAsynPortDriver.cpp:754] adsAsynPortDriver::resolveSymbolInfo: resolving info for 1894 symbols in 4 chunk(s)
2026/08/28 17:14:05.842 [adsAsynPortDriver.cpp:933] adsAsynPortDriver::resolveSymbolInfo: chunk 1/4 done — 500 OK so far
2026/08/28 17:14:05.856 [adsAsynPortDriver.cpp:933] adsAsynPortDriver::resolveSymbolInfo: chunk 2/4 done — 1000 OK so far
2026/08/28 17:14:05.869 [adsAsynPortDriver.cpp:933] adsAsynPortDriver::resolveSymbolInfo: chunk 3/4 done — 1500 OK so far
2026/08/28 17:14:05.879 [adsAsynPortDriver.cpp:933] adsAsynPortDriver::resolveSymbolInfo: chunk 4/4 done — 1894 OK so far
2026/08/28 17:14:05.879 [adsAsynPortDriver.cpp:943] adsAsynPortDriver::resolveSymbolInfo: complete — 1894 resolved, 0 failed (ADS fallback for misses)
2026/08/28 17:14:05.879 [adsAsynPortDriver.cpp:500] adsAsynPortDriver::resolveSymbolHandles: resolving 1894 handles in 4 chunk(s) of max 500
2026/08/28 17:14:05.886 [adsAsynPortDriver.cpp:641] adsAsynPortDriver::resolveSymbolHandles: chunk 1/4 done — 500/1894 resolved
2026/08/28 17:14:05.893 [adsAsynPortDriver.cpp:641] adsAsynPortDriver::resolveSymbolHandles: chunk 2/4 done — 1000/1894 resolved
2026/08/28 17:14:05.901 [adsAsynPortDriver.cpp:641] adsAsynPortDriver::resolveSymbolHandles: chunk 3/4 done — 1500/1894 resolved
2026/08/28 17:14:05.905 [adsAsynPortDriver.cpp:641] adsAsynPortDriver::resolveSymbolHandles: chunk 4/4 done — 1894/1894 resolved
2026/08/28 17:14:05.905 [adsAsynPortDriver.cpp:652] adsAsynPortDriver::resolveSymbolHandles: complete — 1894/1894 handles resolved, 0 will use ADS fallback
Linking EPICS PVs to PLC variables...
1000...
2000...
Database initialization took 1.997851 seconds.
Begin polling PLC!
iocRun: All initialization complete
IOC fully running — total startup time 2.558272 seconds.
# Enable logging
iocLogInit()
# Configure and start the caPutLogger after iocInit
epicsEnvSet(EPICS_AS_PUT_LOG_PV, "ioc-tc-mot-example:caPutLog:Last")
# caPutLogInit("HOST:PORT", config)
# config options:
#       caPutLogNone       -1: no logging (disable)
#       caPutLogOnChange    0: log only on value change
#       caPutLogAll         1: log all puts
#       caPutLogAllNoFilter 2: log all puts no filtering on same PV
caPutLogInit("ctl-logsrv01.pcdsn:7011", 0)
caPutLogInit config: OnChange
log client: connected to log server at "172.21.32.36:7004"
sevr=info caPutLog: successfully initialized
# Start autosave backups
create_monitor_set( "info_positions.req", 10, "" )
log client: connected to log server at "172.21.32.36:7011"
create_monitor_set( "info_settings.req", 60, "" )
ioc-tc-mot-example> 2026/08/28 17:14:08.459 [adsAsynPortDriver.cpp:1389] adsAsynPortDriver:cyclicThread: Device "Plc30 App" connected (Ams-port 851, Ams router version 3.1.2030).
2026/08/28 17:14:08.460 [adsAsynPortDriver.cpp:1412] adsAsynPortDriver:cyclicThread: Ams-port, 851, state change: "UNKNOWN ADSSTATE" -> "ADSSTATE_RUN".
2026/08/28 17:14:08.460 [adsAsynPortDriver.cpp:1412] adsAsynPortDriver:cyclicThread: Ams-port, 350, state change: "UNKNOWN ADSSTATE" -> "ADSSTATE_INVALID".
info_settings.sav: 171 of 171 PV's connected
info_positions.sav: 21495 of 21495 PV's connected
ioc-tc-mot-example> 2026/08/28 17:14:41.131 [EthercatMCAxis.cpp:1358] poll(3) LLS=0
2026/08/28 17:14:41.131 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=1 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=1.23692 time=0.012015
2026/08/28 17:14:45.584 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=0 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=5 time=0.009989
2026/08/28 17:14:50.044 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=1 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=4.20308 time=0.009994
2026/08/28 17:14:54.491 [EthercatMCAxis.cpp:1358] poll(3) LLS=1
2026/08/28 17:14:54.491 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=0 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=0.16 time=0.010007
ioc-tc-mot-example> 2026/08/28 17:15:30.534 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:36.235 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:37.796 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:38.486 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:39.110 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:39.683 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:41.004 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:43.948 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:44.920 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:45.873 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:46.676 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:47.481 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:48.231 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:48.880 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:49.438 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:49.978 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:50.552 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:51.118 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:51.647 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:52.189 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:52.740 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:53.313 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:53.843 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:54.361 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:54.903 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:55.475 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:55.984 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:15:57.184 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:16:18.571 [EthercatMCAxis.cpp:1358] poll(3) LLS=0
2026/08/28 17:16:18.571 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=1 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=5.91778 time=0.010020
ioc-tc-mot-example>
ioc-tc-mot-example> 2026/08/28 17:16:28.477 [EthercatMCAxis.cpp:1364] poll(3) HLS=1
2026/08/28 17:16:28.477 [EthercatMCAxis.cpp:1392] poll(3) mvnNRdy=0 Ver=0 bBusy=0 bExe=0 bEnabled=1 atTarget=0 wf=0 ENC=0 fPos=0 fActPosition=100 time=0.006080
ioc-tc-mot-example> 2026/08/28 17:16:56.883 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:16:58.982 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:16:59.519 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:16:59.981 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:00.739 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:01.424 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:01.891 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:02.567 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:03.024 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:03.506 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:04.028 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:04.552 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:05.101 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:05.809 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:06.429 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:07.126 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:07.818 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:08.310 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:08.975 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:09.515 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:10.010 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:10.537 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
2026/08/28 17:17:11.086 [EthercatMCAxis.cpp:1478] setIntegerParam(3 motorUpdateStatus_)=0
ioc-tc-mot-example>
```